### PR TITLE
Enhance error handling when failing to write cache data

### DIFF
--- a/lib/api_consumer.rb
+++ b/lib/api_consumer.rb
@@ -112,7 +112,13 @@ class APIConsumer
             results = error_code(response.code, opts[:errors], results)
           end
           results = blk.call(results) if blk
-          cache.obj_write(opts[:key], results, :ttl => opts[:ttl]) if opts[:key]
+          begin
+            cache.obj_write(opts[:key], results, :ttl => opts[:ttl]) if opts[:key]
+          rescue Exception => exception
+            # write error messages to the log file but ignore exceptions in writing data to cache
+            log.error exception.message
+            log.error exception.backtrace
+          end
           return results
         elsif( settings[:type] == "rss")
           rss = Nokogiri::XML(response.body)


### PR DESCRIPTION
If there is no memcache server accessible, api_consumer returns a weird error message "{'error': true, 'message': 'API error: 200'}". The error was occurred not by API error, but by memcache writing error. This patch enables API can be used normally despite of memcache writing error.
